### PR TITLE
fix bug when using cell data with `to_mesh_state`

### DIFF
--- a/dash_vtk/utils/vtk.py
+++ b/dash_vtk/utils/vtk.py
@@ -66,7 +66,7 @@ def to_mesh_state(dataset, field_to_keep=None):
     if c_array:
       dataRange = c_array.GetRange(-1)
       nb_comp = c_array.GetNumberOfComponents()
-      values = vtk_to_numpy(p_array).ravel()
+      values = vtk_to_numpy(c_array).ravel()
       js_types = to_js_type[str(values.dtype)]
       location = 'CellData'
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+* fix bug when using cell data with `to_mesh_state`
 
 ## [0.0.6] - 2021-02-22
 


### PR DESCRIPTION
fixing typo where point data is used for cell data in `to_mesh_state`

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines in docs/CONTRIBUTING.md
-->


## About
<!--
What is your PR about? It could be that:
- This is a new component
- I am adding a feature to an existing component, or improving an existing feature
- I am closing an issue
--> 


## Description of changes 
<!--
What does this implement/fix? Explain your changes.
-->

## Pre-Merge checklist
- [ ] The project was correctly built with `npm run build`.
- [ ] If there was any conflict, it was solved correctly.
- [x] All changes were documented in CHANGELOG.md.
- [ ] All tests on CircleCI have passed.
- [ ] All Percy visual changes have been approved.
- [ ] Two people have :dancer:'d the pull request. You can be one of these people if you are a Dash core contributor.


## Reference Issues
<!--
Example: Closes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests

If you are adding a new feature, consider discussing it by opening up an issue.
Otherwise, delete the following line:
-->

Closes #[issue number]


## Other comments