### PR TITLE
Fix use of cell_arrays in to_mesh_state

### DIFF
--- a/dash_vtk/utils/vtk.py
+++ b/dash_vtk/utils/vtk.py
@@ -163,7 +163,7 @@ def to_mesh_state(dataset, field_to_keep=None, point_arrays=None, cell_arrays=No
 
     # other arrays (cells)
     cell_data = []
-    for name in point_arrays:
+    for name in cell_arrays:
         array = polydata.GetCellData().GetArray(name)
         if array:
             dataRange = array.GetRange(-1)

--- a/dash_vtk/utils/vtk.py
+++ b/dash_vtk/utils/vtk.py
@@ -141,6 +141,32 @@ def to_mesh_state(dataset, field_to_keep=None, point_arrays=None, cell_arrays=No
             js_types = to_js_type[str(values.dtype)]
             location = "PointData"
 
+    state = {
+        "mesh": {"points": points,},
+    }
+    if len(verts):
+        state["mesh"]["verts"] = verts
+    if len(lines):
+        state["mesh"]["lines"] = lines
+    if len(polys):
+        state["mesh"]["polys"] = polys
+    if len(strips):
+        state["mesh"]["strips"] = strips
+
+    if values is not None:
+        state.update(
+            {
+                "field": {
+                    "name": field_to_keep,
+                    "values": b64_encode_numpy(values),
+                    "numberOfComponents": nb_comp,
+                    "type": js_types,
+                    "location": location,
+                    "dataRange": dataRange,
+                },
+            }
+        )
+
     # other arrays (points)
     point_data = []
     for name in point_arrays:
@@ -180,32 +206,6 @@ def to_mesh_state(dataset, field_to_keep=None, point_arrays=None, cell_arrays=No
                     "dataRange": dataRange,
                 }
             )
-
-    state = {
-        "mesh": {"points": points,},
-    }
-    if len(verts):
-        state["mesh"]["verts"] = verts
-    if len(lines):
-        state["mesh"]["lines"] = lines
-    if len(polys):
-        state["mesh"]["polys"] = polys
-    if len(strips):
-        state["mesh"]["strips"] = strips
-
-    if values is not None:
-        state.update(
-            {
-                "field": {
-                    "name": field_to_keep,
-                    "values": b64_encode_numpy(values),
-                    "numberOfComponents": nb_comp,
-                    "type": js_types,
-                    "location": location,
-                    "dataRange": dataRange,
-                },
-            }
-        )
 
     if len(point_data):
         state.update({"pointArrays": point_data})


### PR DESCRIPTION
## About

This PR fix the following problems in `to_mesh_state`:

1. `cell_arrays` parameter does not work
2. `field` is written when `point_array` or `cell_arrays` are not empty

## Description of changes 

1. replace `point_arrays` to `cell_arrays`: 8c7c8f4fef2b0088458abb2b0fa74542efb43edd
2. move block code up to avoid non-null `scalars`: 9e2b9b69bd57f3a750da38a1db11be151e99a526

## Pre-Merge checklist
- [ ] The project was correctly built with `npm run build`.
- [ ] If there was any conflict, it was solved correctly.
- [ ] All changes were documented in CHANGELOG.md.
- [ ] All tests on CircleCI have passed.
- [ ] All Percy visual changes have been approved.
- [ ] Two people have :dancer:'d the pull request. You can be one of these people if you are a Dash core contributor.
