### PR TITLE
Add showScalarBar and scalarBarTitle in GeometryRepresentation

### DIFF
--- a/src/lib/components/GeometryRepresentation.react.js
+++ b/src/lib/components/GeometryRepresentation.react.js
@@ -19,6 +19,9 @@ export default function GeometryRepresentation(props) {
 GeometryRepresentation.defaultProps = {
   colorMapPreset: 'erdc_rainbow_bright',
   colorDataRange: [0, 1],
+  showCubeAxes: false,
+  showScalarBar: false,
+  scalarBarTitle: '',
 };
 
 GeometryRepresentation.propTypes = {
@@ -62,6 +65,22 @@ GeometryRepresentation.propTypes = {
    * https://github.com/Kitware/vtk-js/blob/HEAD/Sources/Rendering/Core/CubeAxesActor/index.js#L703-L719
    */
   cubeAxesStyle: PropTypes.object,
+
+  /**
+   * Show hide scalar bar for that representation
+   */
+  showScalarBar: PropTypes.bool,
+
+  /**
+   * Use given string as title for scalar bar. By default it is empty (no title).
+   */
+  scalarBarTitle: PropTypes.string,
+
+  /**
+   * Configure scalar bar style by overriding the set of properties defined
+   * https://github.com/Kitware/vtk-js/blob/master/Sources/Rendering/Core/ScalarBarActor/index.js#L776-L796
+   */
+  scalarBarStyle: PropTypes.object,
 
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),

--- a/src/lib/components/PointCloudRepresentation.react.js
+++ b/src/lib/components/PointCloudRepresentation.react.js
@@ -18,6 +18,9 @@ PointCloudRepresentation.defaultProps = {
   xyz: [0, 0, 0],
   colorMapPreset: 'erdc_rainbow_bright',
   colorDataRange: [0, 1],
+  showCubeAxes: false,
+  showScalarBar: false,
+  scalarBarTitle: '',
 };
 
 PointCloudRepresentation.propTypes = {
@@ -57,4 +60,31 @@ PointCloudRepresentation.propTypes = {
    * Properties to set to the actor.property
    */
   property: PropTypes.object,
+
+  /**
+   * Show/Hide Cube Axes for the given representation
+   */
+  showCubeAxes: PropTypes.bool,
+
+  /**
+   * Configure cube Axes style by overriding the set of properties defined
+   * https://github.com/Kitware/vtk-js/blob/HEAD/Sources/Rendering/Core/CubeAxesActor/index.js#L703-L719
+   */
+  cubeAxesStyle: PropTypes.object,
+
+  /**
+   * Show hide scalar bar for that representation
+   */
+  showScalarBar: PropTypes.bool,
+
+  /**
+   * Use given string as title for scalar bar. By default it is empty (no title).
+   */
+  scalarBarTitle: PropTypes.string,
+
+  /**
+   * Configure scalar bar style by overriding the set of properties defined
+   * https://github.com/Kitware/vtk-js/blob/master/Sources/Rendering/Core/ScalarBarActor/index.js#L776-L796
+   */
+  scalarBarStyle: PropTypes.object,
 };

--- a/usage.py
+++ b/usage.py
@@ -44,6 +44,8 @@ app.layout = html.Div(
                         "pointSize": 10,
                     },
                     colorDataRange=[0, 3],
+                    showScalarBar=True,
+                    scalarBarTitle="Temperature",
                     mapper={
                         "colorByArrayName": "Temperature",
                         "scalarMode": 3,


### PR DESCRIPTION
## Description of changes

This PR enables the use of `showScalarBar` and `scalarBarTitle` in `GeometryRepresentation`:

![image](https://user-images.githubusercontent.com/1608652/153636641-bff4f148-3633-4c0b-9f90-4daf269436d1.png)

## Pre-Merge checklist
- [x] The project was correctly built with `npm run build`.
- [ ] If there was any conflict, it was solved correctly.
- [ ] All changes were documented in CHANGELOG.md.
- [ ] All tests on CircleCI have passed.
- [ ] All Percy visual changes have been approved.
- [ ] Two people have :dancer:'d the pull request. You can be one of these people if you are a Dash core contributor.
