### PR TITLE
Add showOrientationAxes in View

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@plotly/dash-component-plugins": "^1.2.0",
     "ramda": "^0.26.1",
-    "react-vtk-js": "^1.5.1"
+    "react-vtk-js": "^1.10.0"
   },
   "devDependencies": {
     "@babel/core": "^7.5.4",

--- a/src/lib/components/View.react.js
+++ b/src/lib/components/View.react.js
@@ -10,6 +10,7 @@ import { View as VtkItem } from '../AsyncReactVTK';
  *   - `cameraPosition`: [0, 0, 1]
  *   - `cameraViewUp`: [0, 1, 0]
  *   - `cameraParallelProjection`: false
+ *   - `showOrientationAxes`: true
  */
 export default function View(props) {
   return <React.Suspense fallback={null}><VtkItem {...props} /></React.Suspense>;
@@ -62,6 +63,7 @@ View.defaultProps = {
       shift: true,
     },
   ],
+  showOrientationAxes: true,
 };
 
 View.propTypes = {
@@ -142,4 +144,9 @@ View.propTypes = {
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
   ]),
+
+  /**
+   * Show/Hide orientation axes.
+   */
+  showOrientationAxes: PropTypes.bool,
 };


### PR DESCRIPTION
## About

Enable the use of `showOrientationAxes` available in [`react-vtk-js 1.10.0`](https://github.com/Kitware/react-vtk-js/releases/tag/v1.10.0).

## Pre-Merge checklist
- [x] The project was correctly built with `npm run build`.
- [ ] If there was any conflict, it was solved correctly.
- [ ] All changes were documented in CHANGELOG.md.
- [ ] All tests on CircleCI have passed.
- [ ] All Percy visual changes have been approved.
- [ ] Two people have :dancer:'d the pull request. You can be one of these people if you are a Dash core contributor.
